### PR TITLE
mod_labelcollapsed: Tell set_content() that content is already formatted

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -95,7 +95,7 @@ function labelcollapsed_cm_info_view(cm_info $cm) {
 
     require_once(dirname(__FILE__).'/locallib.php');
     $content = labelcollapsed_get_html_content($cm);
-    $cm->set_content($content);
+    $cm->set_content($content, true);
 
 }
 


### PR DESCRIPTION
This prevents the javascript to expand the label being blocked when
'login as...' is being used, fixing issue #12.